### PR TITLE
Fix a formatting typo

### DIFF
--- a/addons/tile_maps_chef/main.gd
+++ b/addons/tile_maps_chef/main.gd
@@ -65,6 +65,6 @@ func _on_custom_button_pressed():
 							polygon = GeometryUtils.polygon_to_local(polygon, cell_pos)
 							nav_data.add_obstruction_outline(polygon)
 	
-	print("Obstruction outlines count: $s" % nav_data.obstruction_outlines.size())
+	print("Obstruction outlines count: %s" % nav_data.obstruction_outlines.size())
 	
 	NavigationServer2D.bake_from_source_geometry_data_async(selected_nav_region.navigation_polygon, nav_data)


### PR DESCRIPTION
Along with being an incorrect formatting directive and erroring out it also seems to prevent the following line (which actually bakes the polygon) from running