### PR TITLE
Redraw navigation region after baking

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Godot plugin to add some functionality to TileMaps
 
 ### Baking NavigationPolygon from multiple layers of TileMap(s)
 This solves issue with Godot's 4.2 baking of TileMaps. If any of you colliders not on `Layer0` of `TileMap`, they will be ignored. This tool scraps all tiles from all the layers (both tile layers and physics layers) and merges as obstructions.
-Select `NavigationRegion2D` first, then hold <kbd>Ctrl</kbd> (or <kbd>⌘ Command</kbd> on Mac) and select any amount of `TileMap`s. On the bottom bar TileChef menu should appear, click it. You will see "Bake NavigationPolygon from TileMaps" button. Click it, polygon should be baked. For some reason it waits for you to switch focus to render your polygon in view, so just click on any node or switch to Output to see your polygons baked.
+Select `NavigationRegion2D` first, then hold <kbd>Ctrl</kbd> (or <kbd>⌘ Command</kbd> on Mac) and select any amount of `TileMap`s. On the bottom bar TileChef menu should appear, click it. You will see "Bake NavigationPolygon from TileMaps" button. Click it, polygon should be baked.
 
 <table>
   <tr>

--- a/addons/tile_maps_chef/main.gd
+++ b/addons/tile_maps_chef/main.gd
@@ -67,4 +67,8 @@ func _on_custom_button_pressed():
 	
 	print("Obstruction outlines count: $s" % nav_data.obstruction_outlines.size())
 	
-	NavigationServer2D.bake_from_source_geometry_data_async(selected_nav_region.navigation_polygon, nav_data)
+	NavigationServer2D.bake_from_source_geometry_data_async(selected_nav_region.navigation_polygon, nav_data, _on_source_geometry_baked)
+
+func _on_source_geometry_baked():
+	if selected_nav_region:
+		selected_nav_region.queue_redraw()


### PR DESCRIPTION
By registering an after-baking callback and queueing a redraw on navigation region we can see the effects immediately and eliminate the need to click around to change focus